### PR TITLE
Handle duplicate error and optin without screening

### DIFF
--- a/base/actions/actions.py
+++ b/base/actions/actions.py
@@ -583,9 +583,11 @@ class TBCheckForm(BaseFormAction):
                         resp = await client.post(url, json=post_data, headers=headers)
                         # TODO: remove print
                         print(resp.content)
-                        resp.raise_for_status()
+                        if not utils.is_duplicate_error(resp):
+                            resp.raise_for_status()
                         break
                 except httpx.HTTPError as e:
+                    print(e)
                     if i == config.HTTP_RETRIES - 1:
                         raise e
 
@@ -620,6 +622,10 @@ class OptInForm(Action):
             url = urljoin(
                 config.HEALTHCONNECT_URL, f"/v2/healthcheckuserprofile/{msisdn}/"
             )
+
+            if not tracker.get_slot("terms"):
+                dispatcher.utter_message(template="utter_do_tb_screening")
+                return []
 
             data = {
                 slot: tracker.get_slot(slot)

--- a/base/actions/utils.py
+++ b/base/actions/utils.py
@@ -34,3 +34,13 @@ def get_risk_templates(risk: Text, data: Dict[Any, Any]) -> List:
         templates.append("utter_follow_up_request")
 
     return templates
+
+
+def is_duplicate_error(response):
+    duplicate = False
+    error = "tb check with this deduplication id already exists."
+
+    if response.content:
+        duplicate = error in response.json().get("deduplication_id", [])
+
+    return duplicate

--- a/base/actions/utils.py
+++ b/base/actions/utils.py
@@ -1,3 +1,4 @@
+from json.decoder import JSONDecodeError
 from typing import Any, Dict, List, Text
 
 
@@ -37,10 +38,8 @@ def get_risk_templates(risk: Text, data: Dict[Any, Any]) -> List:
 
 
 def is_duplicate_error(response):
-    duplicate = False
     error = "tb check with this deduplication id already exists."
-
-    if response.content:
-        duplicate = error in response.json().get("deduplication_id", [])
-
-    return duplicate
+    try:
+        return error in response.json().get("deduplication_id", [])
+    except JSONDecodeError:
+        return False

--- a/base/domain-eng.yml
+++ b/base/domain-eng.yml
@@ -37,6 +37,7 @@ actions:
   - utter_follow_up_request
   - utter_keywords
   - utter_opt_in_yes
+  - utter_do_tb_screening
 
 slots:
   terms:
@@ -279,12 +280,16 @@ responses:
         📌Reply *MENU* to return to the main menu
       claim: release
 
-
   utter_opt_in_yes:
     - text: |
         Thank you for choosing to receive follow-up messages.
 
         📌 Reply with *MENU* to return to the main menu
+      claim: release
+
+  utter_do_tb_screening:
+    - text: |
+        Please reply with *TB* to start your TB check.
       claim: release
 
 # claim: revert will ignore the message text, and reevaluate this message using

--- a/base/tests/test_forms.py
+++ b/base/tests/test_forms.py
@@ -321,7 +321,7 @@ class TestTBCheckForm:
     @pytest.mark.asyncio
     async def test_submit_to_healthconnect_duplicate_check(self):
         """
-        Submits the data to the eventstore in the correct format
+        Should ignore a duplicate contact error from healthconnect
         """
         base.actions.actions.config.HEALTHCONNECT_URL = "https://healthconnect"
         base.actions.actions.config.HEALTHCONNECT_TOKEN = "token"
@@ -441,7 +441,7 @@ class TestOptInForm:
     @pytest.mark.asyncio
     async def test_submit_to_healthconnect_unknown_contact(self):
         """
-        Submits the data to the eventstore in the correct format
+        should not submit data if user has not completed a screening
         """
         base.actions.actions.config.HEALTHCONNECT_URL = "https://healthconnect"
         base.actions.actions.config.HEALTHCONNECT_TOKEN = "token"

--- a/base/tests/test_forms.py
+++ b/base/tests/test_forms.py
@@ -317,6 +317,55 @@ class TestTBCheckForm:
         base.actions.actions.config.HEALTHCONNECT_URL = None
         base.actions.actions.config.HEALTHCONNECT_TOKEN = None
 
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_submit_to_healthconnect_duplicate_check(self):
+        """
+        Submits the data to the eventstore in the correct format
+        """
+        base.actions.actions.config.HEALTHCONNECT_URL = "https://healthconnect"
+        base.actions.actions.config.HEALTHCONNECT_TOKEN = "token"
+
+        request = respx.post(
+            "https://healthconnect/v2/tbcheck/",
+            status_code=400,
+            content={
+                "deduplication_id": [
+                    "tb check with this deduplication id already exists."
+                ]
+            },
+        )
+
+        form = TBCheckForm()
+        dispatcher = CollectingDispatcher()
+        tracker = utils.get_tracker_for_slot_from_intent(
+            form,
+            "tracing",
+            "affirm",
+            {
+                "province": "wc",
+                "age": "18-39",
+                "symptoms_fever": "no",
+                "symptoms_cough": "yes",
+                "symptoms_sweat": "yes",
+                "symptoms_weight": "yes",
+                "exposure": "not sure",
+                "tracing": "yes",
+                "gender": "RATHER NOT SAY",
+                "city_location_coords": "+1.2-3.4",
+                "location_coords": "+3.4-1.2",
+                "location": "Cape Town, South Africa",
+            },
+        )
+        await form.submit(dispatcher, tracker, {})
+
+        assert request.called
+        # [(request, response)] = request.calls
+        # data = json.loads(request.stream.body)
+
+        base.actions.actions.config.HEALTHCONNECT_URL = None
+        base.actions.actions.config.HEALTHCONNECT_TOKEN = None
+
 
 class TestOptInForm:
     @respx.mock
@@ -339,6 +388,7 @@ class TestOptInForm:
             "terms",
             "opt_in",
             {
+                "terms": "yes",
                 "symptoms_fever": "no",
                 "symptoms_cough": "no",
                 "symptoms_sweat": "no",
@@ -373,7 +423,7 @@ class TestOptInForm:
         form = OptInForm()
         dispatcher = CollectingDispatcher()
         tracker = utils.get_tracker_for_slot_from_intent(
-            form, "terms", "opt_in", {"symptoms_cough": "yes"},
+            form, "terms", "opt_in", {"terms": "yes", "symptoms_cough": "yes"},
         )
         await form.run(dispatcher, tracker, {})
 
@@ -383,6 +433,29 @@ class TestOptInForm:
         assert data == {
             "data": {"follow_up_optin": True, "synced_to_tb_rapidpro": False}
         }
+
+        base.actions.actions.config.HEALTHCONNECT_URL = None
+        base.actions.actions.config.HEALTHCONNECT_TOKEN = None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_submit_to_healthconnect_unknown_contact(self):
+        """
+        Submits the data to the eventstore in the correct format
+        """
+        base.actions.actions.config.HEALTHCONNECT_URL = "https://healthconnect"
+        base.actions.actions.config.HEALTHCONNECT_TOKEN = "token"
+
+        request = respx.patch(
+            "https://healthconnect/v2/healthcheckuserprofile/+default/"
+        )
+
+        form = OptInForm()
+        dispatcher = CollectingDispatcher()
+        tracker = utils.get_tracker_for_slot_from_intent(form, "terms", "opt_in", {},)
+        await form.run(dispatcher, tracker, {})
+
+        assert not request.called
 
         base.actions.actions.config.HEALTHCONNECT_URL = None
         base.actions.actions.config.HEALTHCONNECT_TOKEN = None


### PR DESCRIPTION
The `utter_do_tb_screening` copy is not confirmed yet.