### PR TITLE
Fixes

### DIFF
--- a/base/actions/actions.py
+++ b/base/actions/actions.py
@@ -561,6 +561,10 @@ class TBCheckForm(BaseFormAction):
             float(data["latitude"]), float(data["longitude"])
         )
 
+    def merge(self, data_minor, data):
+        data_minor.update(data)
+        return data_minor
+
     def get_healthcheck_data(self, tracker: Tracker, risk: Text) -> Dict[Text, Any]:
         data = {
             "deduplication_id": uuid.uuid4().hex,
@@ -577,22 +581,13 @@ class TBCheckForm(BaseFormAction):
             "exposure": self.YES_NO_MAYBE_MAPPING[tracker.get_slot("exposure")],
             "tracing": self.YES_NO_MAPPING[tracker.get_slot("tracing")],
             "risk": risk,
+            
         }
         if self.AGE_MAPPING[tracker.get_slot("age")] != "<18":
-            data.update(
-                {
-                    "location": self.fix_location_format(
-                        tracker.get_slot("location_coords")
-                    )
-                }
+            data['location'] = self.fix_location_format(tracker.get_slot("location_coords"))
+            data["city_location"] = self.fix_location_format(
+                tracker.get_slot("city_location_coords")
             )
-            data.update(
-                {
-                    "city_location": self.fix_location_format(
-                        tracker.get_slot("city_location_coords")
-                    )
-                }
-            ),
         return data
 
     async def submit(

--- a/base/actions/actions.py
+++ b/base/actions/actions.py
@@ -593,7 +593,6 @@ class TBCheckForm(BaseFormAction):
                     )
                 }
             ),
-        print(data)
         return data
 
     async def submit(

--- a/base/actions/actions.py
+++ b/base/actions/actions.py
@@ -561,12 +561,8 @@ class TBCheckForm(BaseFormAction):
             float(data["latitude"]), float(data["longitude"])
         )
 
-    def merge(self, dict1, dict2):
-        dict1.update(dict2)
-        return dict1
-
     def get_healthcheck_data(self, tracker: Tracker, risk: Text) -> Dict[Text, Any]:
-        dict1 = {
+        data = {
             "deduplication_id": uuid.uuid4().hex,
             "msisdn": f'+{tracker.sender_id.lstrip("+")}',
             "source": "WhatsApp",
@@ -582,15 +578,23 @@ class TBCheckForm(BaseFormAction):
             "tracing": self.YES_NO_MAPPING[tracker.get_slot("tracing")],
             "risk": risk,
         }
-        dict2 = {
-            "location": self.fix_location_format(tracker.get_slot("location_coords")),
-            "city_location": self.fix_location_format(
-                tracker.get_slot("city_location_coords")
+        if self.AGE_MAPPING[tracker.get_slot("age")] != "<18":
+            data.update(
+                {
+                    "location": self.fix_location_format(
+                        tracker.get_slot("location_coords")
+                    )
+                }
+            )
+            data.update(
+                {
+                    "city_location": self.fix_location_format(
+                        tracker.get_slot("city_location_coords")
+                    )
+                }
             ),
-        }
-        if self.AGE_MAPPING[tracker.get_slot("age")] == "<18":
-            return dict1
-        return self.merge(dict1, dict2)
+        print(data)
+        return data
 
     async def submit(
         self,

--- a/base/actions/actions.py
+++ b/base/actions/actions.py
@@ -581,10 +581,11 @@ class TBCheckForm(BaseFormAction):
             "exposure": self.YES_NO_MAYBE_MAPPING[tracker.get_slot("exposure")],
             "tracing": self.YES_NO_MAPPING[tracker.get_slot("tracing")],
             "risk": risk,
-            
         }
         if self.AGE_MAPPING[tracker.get_slot("age")] != "<18":
-            data['location'] = self.fix_location_format(tracker.get_slot("location_coords"))
+            data["location"] = self.fix_location_format(
+                tracker.get_slot("location_coords")
+            )
             data["city_location"] = self.fix_location_format(
                 tracker.get_slot("city_location_coords")
             )

--- a/base/tests/test_forms.py
+++ b/base/tests/test_forms.py
@@ -347,6 +347,7 @@ class TestTBCheckForm:
                 "symptoms_weight": "yes",
                 "exposure": "not sure",
                 "tracing": "yes",
+                "city_location_coords": "",
                 "gender": "RATHER NOT SAY",
                 "location": "<not collected>",
             },
@@ -371,8 +372,6 @@ class TestTBCheckForm:
             "exposure": "not_sure",
             "tracing": True,
             "risk": "moderate",
-            "location": "",
-            "city_location": "",
         }
 
         base.actions.actions.config.HEALTHCONNECT_URL = None


### PR DESCRIPTION
Split dictionaries for <18 and other age options so we do not send any location and city_location data if age < 18. Merge them for other age groups.

- [x] Setup environment, post directly to QA and test that the contact was created (for age <18). 
Contact: https://qa.healthcheck.org.za/admin/tbconnect/tbcheck/513/change/

- [ ] Do same for other age groups. 
Do not have the google places api key so I relied on tests here.