### PR TITLE
Post location only if it's not empty for non-minors

### DIFF
--- a/base/actions/actions.py
+++ b/base/actions/actions.py
@@ -582,13 +582,14 @@ class TBCheckForm(BaseFormAction):
             "tracing": self.YES_NO_MAPPING[tracker.get_slot("tracing")],
             "risk": risk,
         }
+
+        location = self.fix_location_format(tracker.get_slot("location_coords"))
         if self.AGE_MAPPING[tracker.get_slot("age")] != "<18":
-            data["location"] = self.fix_location_format(
-                tracker.get_slot("location_coords")
-            )
             data["city_location"] = self.fix_location_format(
                 tracker.get_slot("city_location_coords")
             )
+            if location != "":
+                data["location"] = location
         return data
 
     async def submit(


### PR DESCRIPTION
For non-minors we need to send location only if it's not empty otherwise the request will fail.
Test contact: https://qa.healthcheck.org.za/admin/tbconnect/tbcheck/516/change/